### PR TITLE
added connectorsProxy contract

### DIFF
--- a/contracts/v2/proxy/connectorsProxy.sol
+++ b/contracts/v2/proxy/connectorsProxy.sol
@@ -1,80 +1,8 @@
 // SPDX-License-Identifier: MIT
+pragma solidity ^0.7.0;
 
-pragma solidity >=0.6.0 <0.8.0;
+import "@openzeppelin/contracts/proxy/TransparentUpgradeableProxy.sol";
 
-import "@openzeppelin/contracts/proxy/UpgradeableProxy.sol";
-
-interface IndexInterface {
-    function master() external view returns (address);
-}
-
-/**
- * @dev This contract implements a proxy that is upgradeable by an admin.
- *
- */
-contract TransparentUpgradeableProxy is UpgradeableProxy {
-    /**
-     * @dev Initializes an upgradeable proxy managed by `_admin`, backed by the implementation at `_logic`, and
-     * optionally initialized with `_data` as explained in {UpgradeableProxy-constructor}.
-     */
-    constructor(address _logic, address admin_, bytes memory _data) public payable UpgradeableProxy(_logic, _data) {
-    }
-
-    /**
-     * @dev InstaIndex contract
-    */
-    IndexInterface internal constant instaIndex = IndexInterface(0x2971AdFa57b20E5a416aE5a708A8655A9c74f723);
-
-    /**
-     * @dev Modifier used internally that will delegate the call to the implementation unless the sender is the admin.
-     */
-    modifier ifAdmin() {
-        if (msg.sender == instaIndex.master()) {
-            _;
-        } else {
-            _fallback();
-        }
-    }
-
-    /**
-     * @dev Returns the current implementation.
-     *
-     * NOTE: Only the admin can call this function. See {ProxyAdmin-getProxyImplementation}.
-     *
-     * TIP: To get this value clients can read directly from the storage slot shown below (specified by EIP1967) using the
-     * https://eth.wiki/json-rpc/API#eth_getstorageat[`eth_getStorageAt`] RPC call.
-     * `0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc`
-     */
-    function implementation() external ifAdmin returns (address implementation_) {
-        implementation_ = _implementation();
-    }
-
-    /**
-     * @dev Upgrade the implementation of the proxy.
-     *
-     * NOTE: Only the admin can call this function. See {ProxyAdmin-upgrade}.
-     */
-    function upgradeTo(address newImplementation) external virtual ifAdmin {
-        _upgradeTo(newImplementation);
-    }
-
-    /**
-     * @dev Upgrade the implementation of the proxy, and then call a function from the new implementation as specified
-     * by `data`, which should be an encoded function call. This is useful to initialize new storage variables in the
-     * proxied contract.
-     *
-     * NOTE: Only the admin can call this function. See {ProxyAdmin-upgradeAndCall}.
-     */
-    function upgradeToAndCall(address newImplementation, bytes calldata data) external payable virtual ifAdmin {
-        _upgradeTo(newImplementation);
-        Address.functionDelegateCall(newImplementation, data);
-    }
-
-    /**
-     * @dev Makes sure the admin cannot access the fallback function. See {Proxy-_beforeFallback}.
-     */
-    function _beforeFallback() internal virtual override {
-        require(msg.sender != instaIndex.master(), "TransparentUpgradeableProxy: master cannot fallback to proxy target");
-        super._beforeFallback();
-    }
+contract InstaConnectorsV2 is TransparentUpgradeableProxy {
+    constructor(address _logic, address admin_, bytes memory _data) public TransparentUpgradeableProxy(_logic, admin_, _data) {}
 }

--- a/contracts/v2/proxy/connectorsProxy.sol
+++ b/contracts/v2/proxy/connectorsProxy.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.8.0;
+
+import "@openzeppelin/contracts/proxy/UpgradeableProxy.sol";
+
+interface IndexInterface {
+    function master() external view returns (address);
+}
+
+/**
+ * @dev This contract implements a proxy that is upgradeable by an admin.
+ *
+ */
+contract TransparentUpgradeableProxy is UpgradeableProxy {
+    /**
+     * @dev Initializes an upgradeable proxy managed by `_admin`, backed by the implementation at `_logic`, and
+     * optionally initialized with `_data` as explained in {UpgradeableProxy-constructor}.
+     */
+    constructor(address _logic, address admin_, bytes memory _data) public payable UpgradeableProxy(_logic, _data) {
+    }
+
+    /**
+     * @dev InstaIndex contract
+    */
+    IndexInterface internal constant instaIndex = IndexInterface(0x2971AdFa57b20E5a416aE5a708A8655A9c74f723);
+
+    /**
+     * @dev Modifier used internally that will delegate the call to the implementation unless the sender is the admin.
+     */
+    modifier ifAdmin() {
+        if (msg.sender == instaIndex.master()) {
+            _;
+        } else {
+            _fallback();
+        }
+    }
+
+    /**
+     * @dev Returns the current implementation.
+     *
+     * NOTE: Only the admin can call this function. See {ProxyAdmin-getProxyImplementation}.
+     *
+     * TIP: To get this value clients can read directly from the storage slot shown below (specified by EIP1967) using the
+     * https://eth.wiki/json-rpc/API#eth_getstorageat[`eth_getStorageAt`] RPC call.
+     * `0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc`
+     */
+    function implementation() external ifAdmin returns (address implementation_) {
+        implementation_ = _implementation();
+    }
+
+    /**
+     * @dev Upgrade the implementation of the proxy.
+     *
+     * NOTE: Only the admin can call this function. See {ProxyAdmin-upgrade}.
+     */
+    function upgradeTo(address newImplementation) external virtual ifAdmin {
+        _upgradeTo(newImplementation);
+    }
+
+    /**
+     * @dev Upgrade the implementation of the proxy, and then call a function from the new implementation as specified
+     * by `data`, which should be an encoded function call. This is useful to initialize new storage variables in the
+     * proxied contract.
+     *
+     * NOTE: Only the admin can call this function. See {ProxyAdmin-upgradeAndCall}.
+     */
+    function upgradeToAndCall(address newImplementation, bytes calldata data) external payable virtual ifAdmin {
+        _upgradeTo(newImplementation);
+        Address.functionDelegateCall(newImplementation, data);
+    }
+
+    /**
+     * @dev Makes sure the admin cannot access the fallback function. See {Proxy-_beforeFallback}.
+     */
+    function _beforeFallback() internal virtual override {
+        require(msg.sender != instaIndex.master(), "TransparentUpgradeableProxy: master cannot fallback to proxy target");
+        super._beforeFallback();
+    }
+}


### PR DESCRIPTION
For now, we can set our master address directly as admin of the proxy contract. 
Later we are going to modify Proxy contract and make ProxyAdmin as admin of the connectorsProxy contract - [ProxyAdmin](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/7c1625b0e024e90415d705d4323c85fbc6ea993c/contracts/proxy/transparent/ProxyAdmin.sol#L9)
And this proxy admin by default will take the master address from InstaIndex.

Why ProxyAdmin?
https://blog.openzeppelin.com/the-transparent-proxy-pattern/
https://medium.com/nomic-labs-blog/malicious-backdoors-in-ethereum-proxies-62629adf3357