### PR TITLE
Support for ERC721 and ERC1155 safeTransfers

### DIFF
--- a/contracts/v2/accounts/default/implementation_default.sol
+++ b/contracts/v2/accounts/default/implementation_default.sol
@@ -2,7 +2,6 @@ pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 import { Variables } from "../variables.sol";
-import "hardhat/console.sol";
 
 interface IndexInterface {
     function list() external view returns (address);

--- a/contracts/v2/accounts/default/implementation_default.sol
+++ b/contracts/v2/accounts/default/implementation_default.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 import {Variables} from "../variables.sol";
+import "hardhat/console.sol";
 
 interface IndexInterface {
     function list() external view returns (address);
@@ -69,9 +70,14 @@ contract Record is Constants {
     }
 
     /**
-    * @dev ERC721 token receiver
-    */
-    function onERC721Received(address, address, uint256, bytes calldata) external returns (bytes4) {
+     * @dev ERC721 token receiver
+     */
+    function onERC721Received(
+        address,
+        address,
+        uint256,
+        bytes calldata
+    ) external returns (bytes4) {
         return 0x150b7a02; // keccak256("onERC721Received(address,address,uint256,bytes)")
     }
 
@@ -85,7 +91,7 @@ contract Record is Constants {
         uint256,
         bytes memory
     ) public pure virtual returns (bytes4) {
-        return this.onERC1155Received.selector;
+        return 0xf23a6e61; // keccak256("onERC1155Received(address,address,uint256,uint256,bytes)")
     }
 
     /**
@@ -98,7 +104,7 @@ contract Record is Constants {
         uint256[] calldata values,
         bytes calldata data
     ) public pure virtual returns (bytes4) {
-        this.onERC1155BatchReceived.selector;
+        return 0xc690df554; // keccak256("onERC1155Received(address,address,uint256[],uint256[],bytes)")
     }
 }
 

--- a/contracts/v2/accounts/default/implementation_default.sol
+++ b/contracts/v2/accounts/default/implementation_default.sol
@@ -104,7 +104,7 @@ contract Record is Constants {
         uint256[] calldata values,
         bytes calldata data
     ) public pure virtual returns (bytes4) {
-        return 0xc690df55; // keccak256("onERC1155Received(address,address,uint256[],uint256[],bytes)")
+        return 0xbc197c81; // keccak256("onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)")
     }
 }
 

--- a/contracts/v2/accounts/default/implementation_default.sol
+++ b/contracts/v2/accounts/default/implementation_default.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
-import { Variables } from "../variables.sol";
+import {Variables} from "../variables.sol";
 
 interface IndexInterface {
     function list() external view returns (address);
@@ -9,15 +9,16 @@ interface IndexInterface {
 
 interface ListInterface {
     function addAuth(address user) external;
+
     function removeAuth(address user) external;
 }
 
 contract Constants is Variables {
-    uint public constant implementationVersion = 1;
+    uint256 public constant implementationVersion = 1;
     // InstaIndex Address.
     address public immutable instaIndex;
     // The Account Module Version.
-    uint public constant version = 2;
+    uint256 public constant version = 2;
 
     constructor(address _instaIndex) {
         instaIndex = _instaIndex;
@@ -41,9 +42,12 @@ contract Record is Constants {
     /**
      * @dev Enable New User.
      * @param user Owner address
-    */
+     */
     function enable(address user) public {
-        require(msg.sender == address(this) || msg.sender == instaIndex, "not-self-index");
+        require(
+            msg.sender == address(this) || msg.sender == instaIndex,
+            "not-self-index"
+        );
         require(user != address(0), "not-valid");
         require(!_auth[user], "already-enabled");
         _auth[user] = true;
@@ -54,7 +58,7 @@ contract Record is Constants {
     /**
      * @dev Disable User.
      * @param user Owner address
-    */
+     */
     function disable(address user) public {
         require(msg.sender == address(this), "not-self");
         require(user != address(0), "not-valid");
@@ -64,10 +68,41 @@ contract Record is Constants {
         emit LogDisableUser(user);
     }
 
+    /**
+    * @dev ERC721 token receiver
+    */
+    function onERC721Received(address, address, uint256, bytes calldata) external returns (bytes4) {
+        return 0x150b7a02; // keccak256("onERC721Received(address,address,uint256,bytes)")
+    }
+
+    /**
+     * @dev ERC1155 token receiver
+     */
+    function onERC1155Received(
+        address,
+        address,
+        uint256,
+        uint256,
+        bytes memory
+    ) public pure virtual returns (bytes4) {
+        return this.onERC1155Received.selector;
+    }
+
+    /**
+     * @dev ERC1155 token receiver
+     */
+    function onERC1155BatchReceived(
+        address operator,
+        address from,
+        uint256[] calldata ids,
+        uint256[] calldata values,
+        bytes calldata data
+    ) public pure virtual returns (bytes4) {
+        this.onERC1155BatchReceived.selector;
+    }
 }
 
 contract InstaDefaultImplementation is Record {
-
     constructor(address _instaIndex) public Record(_instaIndex) {}
 
     receive() external payable {}

--- a/contracts/v2/accounts/default/implementation_default.sol
+++ b/contracts/v2/accounts/default/implementation_default.sol
@@ -104,7 +104,7 @@ contract Record is Constants {
         uint256[] calldata values,
         bytes calldata data
     ) public pure virtual returns (bytes4) {
-        return 0xc690df554; // keccak256("onERC1155Received(address,address,uint256[],uint256[],bytes)")
+        return 0xc690df55; // keccak256("onERC1155Received(address,address,uint256[],uint256[],bytes)")
     }
 }
 

--- a/contracts/v2/accounts/default/implementation_default.sol
+++ b/contracts/v2/accounts/default/implementation_default.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
-import {Variables} from "../variables.sol";
+import { Variables } from "../variables.sol";
 import "hardhat/console.sol";
 
 interface IndexInterface {
@@ -78,7 +78,7 @@ contract Record is Constants {
         uint256,
         bytes calldata
     ) external returns (bytes4) {
-        return 0x150b7a02; // keccak256("onERC721Received(address,address,uint256,bytes)")
+        return 0x150b7a02; // bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))
     }
 
     /**
@@ -90,21 +90,21 @@ contract Record is Constants {
         uint256,
         uint256,
         bytes memory
-    ) public pure virtual returns (bytes4) {
-        return 0xf23a6e61; // keccak256("onERC1155Received(address,address,uint256,uint256,bytes)")
+    ) external returns (bytes4) {
+        return 0xf23a6e61; // bytes4(keccak256("onERC1155Received(address,address,uint256,uint256,bytes)"))
     }
 
     /**
      * @dev ERC1155 token receiver
      */
     function onERC1155BatchReceived(
-        address operator,
-        address from,
-        uint256[] calldata ids,
-        uint256[] calldata values,
-        bytes calldata data
-    ) public pure virtual returns (bytes4) {
-        return 0xbc197c81; // keccak256("onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)")
+        address,
+        address,
+        uint256[] calldata,
+        uint256[] calldata,
+        bytes calldata
+    ) external returns (bytes4) {
+        return 0xbc197c81; // bytes4(keccak256("onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))
     }
 }
 

--- a/test/ERC721AndERC1155.test.js
+++ b/test/ERC721AndERC1155.test.js
@@ -4,19 +4,9 @@ const { web3, deployments, waffle } = hre;
 const { provider, deployContract } = waffle
 
 const deployContracts = require("../scripts/deployContracts")
-const deployConnector = require("../scripts/deployConnector")
-const enableConnector = require("../scripts/enableConnector")
-
-const encodeSpells = require("../scripts/encodeSpells.js")
-const expectEvent = require("../scripts/expectEvent")
 
 const getMasterSigner = require("../scripts/getMasterSigner")
 
-const addresses = require("../scripts/constant/addresses");
-const abis = require("../scripts/constant/abis");
-
-const compoundArtifact = require("../artifacts/contracts/v2/connectors/test/compound.test.sol/ConnectCompound.json");
-const connectAuth = require("../artifacts/contracts/v2/connectors/test/auth.test.sol/ConnectV2Auth.json");
 const defaultTest2 = require("../artifacts/contracts/v2/accounts/test/implementation_default.v2.test.sol/InstaDefaultImplementationV2.json");
 const { ethers } = require("hardhat");
 

--- a/test/nfttransfer.test.js
+++ b/test/nfttransfer.test.js
@@ -1,0 +1,136 @@
+const { expect } = require("chai");
+const hre = require("hardhat");
+const { web3, deployments, waffle } = hre;
+const { provider, deployContract } = waffle
+
+const deployContracts = require("../scripts/deployContracts")
+const deployConnector = require("../scripts/deployConnector")
+const enableConnector = require("../scripts/enableConnector")
+
+const encodeSpells = require("../scripts/encodeSpells.js")
+const expectEvent = require("../scripts/expectEvent")
+
+const getMasterSigner = require("../scripts/getMasterSigner")
+
+const addresses = require("../scripts/constant/addresses");
+const abis = require("../scripts/constant/abis");
+
+const compoundArtifact = require("../artifacts/contracts/v2/connectors/test/compound.test.sol/ConnectCompound.json");
+const connectAuth = require("../artifacts/contracts/v2/connectors/test/auth.test.sol/ConnectV2Auth.json");
+const defaultTest2 = require("../artifacts/contracts/v2/accounts/test/implementation_default.v2.test.sol/InstaDefaultImplementationV2.json");
+const { ethers } = require("hardhat");
+
+const { abi: ERC721Abi } = require("@openzeppelin/contracts/build/contracts/IERC721.json");
+const { abi: ERC1155Abi } = require("@openzeppelin/contracts/build/contracts/IERC1155.json");
+const ERC721_CONTRACT_ADDR = "0x4d695c615a7aacf2d7b9c481b66045bb2457dfde";
+const ERC721_HOLDER_ADDR = "0x8c6b10d42ff08e56133fca0dac75e1931b1fcc23";
+const ERC721_ID = "38"
+
+const ERC1155_CONTRACT_ADDR = "0x1ca3262009b21F944e6b92a2a88D039D06F1acFa";
+const ERC1155_OWNER = "0x76df7482f201378121da29ba4d3883176a468bf4";
+const ERC1155_ID = "5"
+
+describe("NFT-Transfer", function () {
+    const address_zero = "0x0000000000000000000000000000000000000000"
+
+    let
+        instaConnectorsV2,
+        implementationsMapping,
+        instaAccountV2Proxy,
+        instaAccountV2ImplM1,
+        instaAccountV2ImplM2,
+        instaAccountV2DefaultImpl,
+        instaAccountV2DefaultImplV2,
+        instaIndex
+
+    let masterSigner;
+
+    before(async () => {
+        this.timeout = 10000000;
+        const result = await deployContracts()
+        instaAccountV2DefaultImpl = result.instaAccountV2DefaultImpl
+        instaIndex = result.instaIndex
+        instaConnectorsV2 = result.instaConnectorsV2
+        implementationsMapping = result.implementationsMapping
+        instaAccountV2Proxy = result.instaAccountV2Proxy
+        instaAccountV2ImplM1 = result.instaAccountV2ImplM1
+        instaAccountV2ImplM2 = result.instaAccountV2ImplM2
+
+        masterSigner = await getMasterSigner();
+
+        instaAccountV2DefaultImplV2 = await deployContract(masterSigner, defaultTest2, [])
+    })
+
+    it("Should have contracts deployed.", async function () {
+        expect(!!instaConnectorsV2.address).to.be.true;
+        expect(!!implementationsMapping.address).to.be.true;
+        expect(!!instaAccountV2Proxy.address).to.be.true;
+        expect(!!instaAccountV2ImplM1.address).to.be.true;
+        expect(!!instaAccountV2ImplM2.address).to.be.true;
+    });
+
+    describe("Implementations", function () {
+
+        it("Should add default implementation to mapping.", async function () {
+            const tx = await implementationsMapping.connect(masterSigner).setDefaultImplementation(instaAccountV2DefaultImpl.address);
+            await tx.wait()
+            expect(await implementationsMapping.defaultImplementation()).to.be.equal(instaAccountV2DefaultImpl.address);
+        });
+
+        it("Should add InstaAccountV2 in Index.sol", async function () {
+            const tx = await instaIndex.connect(masterSigner).addNewAccount(instaAccountV2Proxy.address, address_zero, address_zero)
+            await tx.wait()
+            expect(await instaIndex.account(2)).to.be.equal(instaAccountV2Proxy.address);
+        });
+
+    });
+
+    describe("Should transfer NFT successfully", () => {
+        let ERC721Contract;
+        let ERC721Owner;
+        let ERC1155Contract, ERC1155Owner;
+        before(async () => {
+            this.timeout = 100000000;
+            await hre.network.provider.request({
+                method: "hardhat_impersonateAccount",
+                params: [ERC1155_OWNER],
+            });
+
+            await network.provider.send("hardhat_setBalance", [
+                ERC1155_OWNER,
+                "0x1000000000000000",
+            ]);
+
+            // get tokenOwner
+            ERC1155Owner = await ethers.getSigner(
+                ERC1155_OWNER
+            );
+            ERC1155Contract = await ethers.getContractAt(ERC1155Abi, ERC1155_CONTRACT_ADDR, ERC1155_OWNER);
+
+            await hre.network.provider.request({
+                method: "hardhat_impersonateAccount",
+                params: [ERC721_HOLDER_ADDR],
+            });
+
+            // get tokenOwner
+            ERC721Owner = await ethers.getSigner(
+                ERC721_HOLDER_ADDR
+            );
+            ERC721Contract = await ethers.getContractAt(ERC721Abi, ERC721_CONTRACT_ADDR, ERC721Owner);
+        });
+
+        it("should transfer NFT successfully", async () => {
+            let account = await instaIndex.account(2)
+            await ERC721Contract["safeTransferFrom(address,address,uint256)"](ERC721Owner.address, account, ERC721_ID);
+            let accountBalance = await ERC721Contract.balanceOf(account);
+            expect(accountBalance.toNumber()).equal(1);
+        });
+
+        it("should transfer ERC1155 successfully", async () => {
+            let account = await instaIndex.account(2)
+            await ERC1155Contract["safeTransferFrom(address,address,uint256,uint256,bytes)"](ERC1155_OWNER, account, ERC1155_ID, "1", ethers.utils.arrayify("0x01"));
+            let accountBalance = await ERC1155Contract.balanceOf(account, ERC1155_ID);
+            expect(accountBalance.toNumber()).equal(1);
+        });
+    })
+});


### PR DESCRIPTION
- Added `onERC721Received()` to support `safeTransfers` from ERC721 contracts. 
- Added `onERC1155Received()` and `onERC1155BatchReceived()` to support `safeTransfers` from ERC1155 contracts. 